### PR TITLE
Specify 1em diameter on the spinner so it will always match the icon size

### DIFF
--- a/src/components/StatusIcon/StatusIcon.css
+++ b/src/components/StatusIcon/StatusIcon.css
@@ -1,0 +1,3 @@
+span.pf-c-spinner.status-icon-loading-spinner {
+  --pf-c-spinner--diameter: 1em;
+}

--- a/src/components/StatusIcon/StatusIcon.test.tsx
+++ b/src/components/StatusIcon/StatusIcon.test.tsx
@@ -9,7 +9,6 @@ import {
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 import { StatusIcon, StatusType, IStatusIconProps } from './StatusIcon';
-import { spinnerSize } from '@patternfly/react-core';
 
 const checkColor = (props: IStatusIconProps, color: string) => {
   const { container } = render(<StatusIcon {...props} />);
@@ -27,12 +26,6 @@ const checkText = (props: IStatusIconProps, text: string) => {
   const { container } = render(<StatusIcon {...props} />);
   const icon = container.querySelector('.pf-l-flex');
   expect(icon).toContainHTML(text);
-};
-
-const checkSize = (props: IStatusIconProps, size: string, selector: string) => {
-  const { container } = render(<StatusIcon {...props} />);
-  const icon = container.querySelector(selector);
-  expect(icon).toHaveClass(size);
 };
 
 describe('StatusIcon', () => {
@@ -102,9 +95,6 @@ describe('StatusIcon', () => {
     });
     it('should pass down a given className', () => {
       checkClass({ status: StatusType.Loading, className: 'foo' }, 'foo', 'span');
-    });
-    it('should pass down a given size', () => {
-      checkSize({ status: StatusType.Loading, size: spinnerSize.md }, 'pf-m-md', 'span');
     });
   });
 });

--- a/src/components/StatusIcon/StatusIcon.tsx
+++ b/src/components/StatusIcon/StatusIcon.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Flex, FlexItem, Spinner, spinnerSize } from '@patternfly/react-core';
+import { Flex, FlexItem, Spinner } from '@patternfly/react-core';
 import {
   CheckCircleIcon,
   WarningTriangleIcon,
@@ -14,6 +14,8 @@ import {
   global_info_color_100 as infoColor,
 } from '@patternfly/react-tokens';
 
+import './StatusIcon.css';
+
 export enum StatusType {
   Ok = 'Ok',
   Warning = 'Warning',
@@ -27,7 +29,6 @@ export interface IStatusIconProps {
   label?: React.ReactNode;
   isDisabled?: boolean;
   className?: string;
-  size?: spinnerSize;
 }
 
 export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
@@ -35,7 +36,6 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
   label,
   isDisabled = false,
   className = '',
-  size = spinnerSize.sm,
 }: IStatusIconProps) => {
   let icon: React.ReactElement | null = null;
   if (status === StatusType.Ok) {
@@ -71,7 +71,7 @@ export const StatusIcon: React.FunctionComponent<IStatusIconProps> = ({
     );
   }
   if (status === StatusType.Loading) {
-    icon = <Spinner className={className} size={size} />;
+    icon = <Spinner className={`${className} status-icon-loading-spinner`} />;
   }
   if (label) {
     return (


### PR DESCRIPTION
@gildub here's a solution for your spinner spacing problem. Instead of using a size prop on the spinner at all, we can use CSS to set its diameter to 1em which will always make it match the font size (just like the normal icons do). This makes it the exact same size as the other variants, and if you modify the font size of the container it will scale to match.

PR is against your branch, if you like it we can merge this to make it a part of your PR https://github.com/konveyor/lib-ui/pull/30 .